### PR TITLE
Add account takeover protection

### DIFF
--- a/contrib/application/account_takeover.go
+++ b/contrib/application/account_takeover.go
@@ -1,0 +1,13 @@
+package application
+
+import (
+	"context"
+
+	"github.com/sitebatch/waffle-go/internal/emitter/account_takeover"
+)
+
+// ProtectAccountTakeover protects account takeover from attacks such as brute force attack, credential stuffing
+// NOTE: Login attempt statistics are stored in memory, so be aware that rate limiting may not work accurately if you are using a distributed system
+func ProtectAccountTakeover(ctx context.Context, clientIP string, userID string) error {
+	return account_takeover.IsSuspiciousLoginActivity(ctx, clientIP, userID)
+}

--- a/example/sql/go.mod
+++ b/example/sql/go.mod
@@ -41,6 +41,7 @@ require (
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
+	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/example/sql/go.sum
+++ b/example/sql/go.sum
@@ -30,6 +30,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
 github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -91,6 +93,8 @@ golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
+golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=

--- a/example/sql/main.go
+++ b/example/sql/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sitebatch/waffle-go"
+	"github.com/sitebatch/waffle-go/contrib/application"
 	waffleSQL "github.com/sitebatch/waffle-go/contrib/database/sql"
 	ginWaf "github.com/sitebatch/waffle-go/contrib/gin-gonic/gin"
 )
@@ -40,6 +41,13 @@ func main() {
 func loginController(c *gin.Context) {
 	email := c.PostForm("email")
 	password := c.PostForm("password")
+
+	if err := application.ProtectAccountTakeover(c.Request.Context(), c.ClientIP(), email); err != nil {
+		c.JSON(429, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
 
 	err := login(c.Request.Context(), email, password)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.23.4
 require (
 	github.com/ebitengine/purego v0.8.1
 	github.com/gin-gonic/gin v1.10.0
+	github.com/google/uuid v1.6.0
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/stretchr/testify v1.10.0
 	github.com/wasilibs/go-re2 v1.8.0
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
+	golang.org/x/time v0.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
 github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -91,6 +93,8 @@ golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
+golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=

--- a/internal/emitter/account_takeover/handler.go
+++ b/internal/emitter/account_takeover/handler.go
@@ -1,0 +1,67 @@
+package account_takeover
+
+import (
+	"context"
+
+	"github.com/sitebatch/waffle-go/internal/emitter/http"
+	"github.com/sitebatch/waffle-go/internal/emitter/waf"
+	"github.com/sitebatch/waffle-go/internal/operation"
+)
+
+type ProtectLoginOperation struct {
+	operation.Operation
+
+	*waf.WafOperation
+}
+
+type ProtectLoginOperationArg struct {
+	ClientIP string
+	UserID   string
+}
+
+type ProtectLoginOperationResult struct {
+	BlockErr error
+}
+
+func (ProtectLoginOperationArg) IsArgOf(*ProtectLoginOperation)        {}
+func (*ProtectLoginOperationResult) IsResultOf(*ProtectLoginOperation) {}
+
+func (r *ProtectLoginOperationResult) IsBlock() bool {
+	return r.BlockErr != nil
+}
+
+func IsSuspiciousLoginActivity(
+	ctx context.Context,
+	clientIP string,
+	userID string,
+) error {
+	parent, _ := operation.FindOperationFromContext(ctx)
+	if parent == nil {
+		return nil
+	}
+
+	var wafop *waf.WafOperation
+	if parentOp, ok := parent.(*http.HTTPRequestHandlerOperation); ok {
+		wafop = parentOp.WafOperation
+	} else {
+		wafop, _ = waf.StartWafOperation(ctx)
+	}
+
+	op := &ProtectLoginOperation{
+		Operation:    operation.NewOperation(parent),
+		WafOperation: wafop,
+	}
+
+	operation.StartOperation(
+		op, ProtectLoginOperationArg{ClientIP: clientIP, UserID: userID},
+	)
+
+	res := &ProtectLoginOperationResult{}
+	operation.FinishOperation(op, res)
+
+	if res.BlockErr != nil {
+		return res.BlockErr
+	}
+
+	return nil
+}

--- a/internal/emitter/waf/waf.go
+++ b/internal/emitter/waf/waf.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sitebatch/waffle-go/internal/inspector"
 	"github.com/sitebatch/waffle-go/internal/log"
 	"github.com/sitebatch/waffle-go/internal/rule"
+	"golang.org/x/time/rate"
 )
 
 type detectionResult struct {
@@ -171,6 +172,11 @@ func (w *waf) doInspect(i inspector.Inspector, data inspector.InspectData, condi
 
 	case inspector.SSRFInspectorName:
 		return i.Inspect(data, &inspector.SSRFInspectorArgs{})
+
+	case inspector.AccountTakeoverInspectorName:
+		return i.Inspect(data, &inspector.AccountTakeoverInspectorArgs{
+			LoginRateLimitPerSecond: rate.Limit(condition.Threshold),
+		})
 
 	default:
 		log.Warn("Unknown inspector", "name", i.Name())

--- a/internal/inspector/account_takeover.go
+++ b/internal/inspector/account_takeover.go
@@ -1,0 +1,53 @@
+package inspector
+
+import (
+	"github.com/sitebatch/waffle-go/internal/action"
+	"github.com/sitebatch/waffle-go/internal/inspector/account_takeover"
+	"golang.org/x/time/rate"
+)
+
+type AccountTakeoverInspector struct{}
+type AccountTakeoverInspectorArgs struct {
+	LoginRateLimitPerSecond rate.Limit
+}
+
+func (a *AccountTakeoverInspectorArgs) IsArgOf() string {
+	return string(AccountTakeoverInspectorName)
+}
+
+func NewAccountTakeoverInspector() Inspector {
+	return &AccountTakeoverInspector{}
+}
+
+func (i *AccountTakeoverInspector) Name() InspectorName {
+	return AccountTakeoverInspectorName
+}
+
+func (i *AccountTakeoverInspector) IsSupportTarget(target InspectTarget) bool {
+	return target == InspectTargetAccountTakeover
+}
+
+func (i *AccountTakeoverInspector) Inspect(inspectData InspectData, args InspectorArgs) error {
+	inspectorArgs, ok := args.(*AccountTakeoverInspectorArgs)
+	if !ok {
+		return nil
+	}
+
+	inspectValue := inspectData.Target[InspectTargetAccountTakeover]
+	if inspectValue == nil {
+		return nil
+	}
+
+	clientIP := inspectValue.GetValues(WithParamNames([]string{"client_ip"}))
+	userID := inspectValue.GetValues(WithParamNames([]string{"user_id"}))
+
+	if len(clientIP) == 0 || len(userID) == 0 {
+		return nil
+	}
+
+	if err := account_takeover.IsLimit(clientIP[0], userID[0], inspectorArgs.LoginRateLimitPerSecond); err != nil {
+		return &action.DetectionError{Reason: err.Error()}
+	}
+
+	return nil
+}

--- a/internal/inspector/account_takeover/login.go
+++ b/internal/inspector/account_takeover/login.go
@@ -1,0 +1,67 @@
+package account_takeover
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sitebatch/waffle-go/lib/limitter"
+	"golang.org/x/time/rate"
+)
+
+var loginLimittersPerIPAddress = make(map[string]RateLimitter)
+var loginLimittersPerIPAddressLock sync.Mutex
+
+var loginLimittersPerUserID = make(map[string]RateLimitter)
+var loginLimittersPerUserIDLock sync.Mutex
+
+type RateLimitter interface {
+	Allow() bool
+}
+
+func IsLimit(ip string, userID string, rate rate.Limit) error {
+	if IsLimitedByIPAddress(ip, rate) {
+		return fmt.Errorf("IP address %s is reached limit", ip)
+	}
+
+	if IsLimitedByUserID(userID, rate) {
+		return fmt.Errorf("userID %s is reached limited", userID)
+	}
+
+	return nil
+}
+
+func IsLimitedByIPAddress(ip string, rate rate.Limit) bool {
+	loginLimittersPerIPAddressLock.Lock()
+	defer loginLimittersPerIPAddressLock.Unlock()
+
+	if _, ok := loginLimittersPerIPAddress[ip]; !ok {
+		loginLimittersPerIPAddress[ip] = limitter.NewLimitter(rate, int(rate))
+	}
+
+	return !loginLimittersPerIPAddress[ip].Allow()
+}
+
+func IsLimitedByUserID(userID string, rate rate.Limit) bool {
+	loginLimittersPerUserIDLock.Lock()
+	defer loginLimittersPerUserIDLock.Unlock()
+
+	if _, ok := loginLimittersPerUserID[userID]; !ok {
+		loginLimittersPerUserID[userID] = limitter.NewLimitter(rate, int(rate))
+	}
+
+	return !loginLimittersPerUserID[userID].Allow()
+}
+
+func ClearLimitByIP(ip string) {
+	loginLimittersPerIPAddressLock.Lock()
+	defer loginLimittersPerIPAddressLock.Unlock()
+
+	delete(loginLimittersPerIPAddress, ip)
+}
+
+func ClearLimitByUserID(userID string) {
+	loginLimittersPerUserIDLock.Lock()
+	defer loginLimittersPerUserIDLock.Unlock()
+
+	delete(loginLimittersPerUserID, userID)
+}

--- a/internal/inspector/account_takeover_test.go
+++ b/internal/inspector/account_takeover_test.go
@@ -1,0 +1,156 @@
+package inspector_test
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sitebatch/waffle-go/internal/action"
+	"github.com/sitebatch/waffle-go/internal/inspector"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+func TestAccountTakeoverInspector_Inspect(t *testing.T) {
+	type arrange struct {
+		inspectData   inspector.InspectData
+		inspectorArgs inspector.InspectorArgs
+	}
+
+	testCases := map[string]struct {
+		arrange
+		randomizeTo string
+		reqSize     int
+		detected    bool
+	}{
+		"single IP address that make a lot of login request": {
+			arrange: arrange{
+				inspectData: inspector.InspectData{
+					Target: map[inspector.InspectTarget]inspector.InspectTargetValue{
+						inspector.InspectTargetAccountTakeover: inspector.NewInspectTargetValueKeyValues(
+							map[string][]string{
+								"client_ip": {"192.168.1.1"},
+								"user_id":   {generateDummyUserID(t)},
+							},
+						),
+					},
+				},
+				inspectorArgs: &inspector.AccountTakeoverInspectorArgs{
+					LoginRateLimitPerSecond: rate.Limit(10),
+				},
+			},
+			randomizeTo: "user_id",
+			reqSize:     11,
+			detected:    true,
+		},
+		"single user id that make a lot of login request": {
+			arrange: arrange{
+				inspectData: inspector.InspectData{
+					Target: map[inspector.InspectTarget]inspector.InspectTargetValue{
+						inspector.InspectTargetAccountTakeover: inspector.NewInspectTargetValueKeyValues(
+							map[string][]string{
+								"client_ip": {generateDummyIP(t)},
+								"user_id":   {"user@example.com"},
+							},
+						),
+					},
+				},
+				inspectorArgs: &inspector.AccountTakeoverInspectorArgs{
+					LoginRateLimitPerSecond: rate.Limit(10),
+				},
+			},
+			randomizeTo: "client_ip",
+			reqSize:     11,
+			detected:    true,
+		},
+		"single IP address no reache limit": {
+			arrange: arrange{
+				inspectData: inspector.InspectData{
+					Target: map[inspector.InspectTarget]inspector.InspectTargetValue{
+						inspector.InspectTargetAccountTakeover: inspector.NewInspectTargetValueKeyValues(
+							map[string][]string{
+								"client_ip": {"10.0.1.1"},
+								"user_id":   {generateDummyUserID(t)},
+							},
+						),
+					},
+				},
+				inspectorArgs: &inspector.AccountTakeoverInspectorArgs{
+					LoginRateLimitPerSecond: rate.Limit(10),
+				},
+			},
+			randomizeTo: "user_id",
+			reqSize:     5,
+			detected:    false,
+		},
+		"single user id no reache limit": {
+			arrange: arrange{
+				inspectData: inspector.InspectData{
+					Target: map[inspector.InspectTarget]inspector.InspectTargetValue{
+						inspector.InspectTargetAccountTakeover: inspector.NewInspectTargetValueKeyValues(
+							map[string][]string{
+								"client_ip": {generateDummyIP(t)},
+								"user_id":   {"user@example.jp"},
+							},
+						),
+					},
+				},
+				inspectorArgs: &inspector.AccountTakeoverInspectorArgs{
+					LoginRateLimitPerSecond: rate.Limit(10),
+				},
+			},
+			randomizeTo: "client_ip",
+			reqSize:     5,
+			detected:    false,
+		},
+	}
+
+	for name, tt := range testCases {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			var err error
+			for i := 0; i < tt.reqSize; i++ {
+				i := inspector.NewAccountTakeoverInspector()
+
+				if tt.randomizeTo == "client_ip" {
+					tt.arrange.inspectData.Target[inspector.InspectTargetAccountTakeover].(*inspector.InspectTargetValueKeyValues).Values["client_ip"][0] = generateDummyIP(t)
+				}
+
+				if tt.randomizeTo == "user_id" {
+					tt.arrange.inspectData.Target[inspector.InspectTargetAccountTakeover].(*inspector.InspectTargetValueKeyValues).Values["user_id"][0] = generateDummyUserID(t)
+				}
+
+				err = i.Inspect(tt.arrange.inspectData, tt.arrange.inspectorArgs)
+			}
+
+			if tt.detected {
+				assert.Error(t, err)
+
+				var detectionError *action.DetectionError
+				assert.ErrorAs(t, err, &detectionError)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func generateDummyUserID(t *testing.T) string {
+	t.Helper()
+
+	return uuid.New().String()
+}
+
+func generateDummyIP(t *testing.T) string {
+	t.Helper()
+
+	size := 4
+	ip := make([]byte, size)
+	for i := 0; i < size; i++ {
+		ip[i] = byte(rand.Intn(256))
+	}
+	return net.IP(ip).To4().String()
+}

--- a/internal/inspector/inspector.go
+++ b/internal/inspector/inspector.go
@@ -10,6 +10,7 @@ var (
 	SQLiInspectorName             InspectorName = "SQLiInspector"
 	LFIInspectorName              InspectorName = "LFIInspector"
 	SSRFInspectorName             InspectorName = "SSRFInspector"
+	AccountTakeoverInspectorName  InspectorName = "AccountTakeoverInspector"
 )
 
 func NewInspector() map[string]Inspector {
@@ -21,6 +22,7 @@ func NewInspector() map[string]Inspector {
 		string("sqli"):              NewSQLiInspector(),
 		string("lfi"):               NewLFIInspector(),
 		string("ssrf"):              NewSSRFInspector(),
+		string("account_takeover"):  NewAccountTakeoverInspector(),
 	}
 }
 

--- a/internal/inspector/target.go
+++ b/internal/inspector/target.go
@@ -19,6 +19,8 @@ const (
 
 	InspectTargetSQLQuery   InspectTarget = "sql.query"
 	InspectTargetOSFileOpen InspectTarget = "os.file.open"
+
+	InspectTargetAccountTakeover InspectTarget = "application.user.login.account_takeover"
 )
 
 func (t InspectTarget) String() string {
@@ -87,6 +89,14 @@ func (b *InspectDataBuilder) WithSQLQuery(query string) *InspectDataBuilder {
 
 func (b *InspectDataBuilder) WithFileOpenPath(path string) *InspectDataBuilder {
 	b.Target[InspectTargetOSFileOpen] = NewInspectTargetValueString(path)
+	return b
+}
+
+func (b *InspectDataBuilder) WithAccountTakeover(clientIP, userID string) *InspectDataBuilder {
+	b.Target[InspectTargetAccountTakeover] = NewInspectTargetValueKeyValues(map[string][]string{
+		"client_ip": {clientIP},
+		"user_id":   {userID},
+	})
 	return b
 }
 

--- a/internal/listener/account_takeover/listener.go
+++ b/internal/listener/account_takeover/listener.go
@@ -1,0 +1,38 @@
+package account_takeover
+
+import (
+	"github.com/sitebatch/waffle-go/internal/emitter/account_takeover"
+	"github.com/sitebatch/waffle-go/internal/emitter/waf"
+	"github.com/sitebatch/waffle-go/internal/inspector"
+	"github.com/sitebatch/waffle-go/internal/listener"
+	"github.com/sitebatch/waffle-go/internal/operation"
+)
+
+type AccountTakeoverSecurity struct {
+}
+
+func (s *AccountTakeoverSecurity) Name() string {
+	return "account_takeover_security"
+}
+
+func NewAccountTakeoverSecurity(rootOp operation.Operation) (listener.Listener, error) {
+	accountTakeoverSec := &AccountTakeoverSecurity{}
+
+	operation.OnStart(rootOp, accountTakeoverSec.OnLogin)
+	operation.OnFinish(rootOp, accountTakeoverSec.OnFinish)
+
+	return accountTakeoverSec, nil
+}
+
+func (s *AccountTakeoverSecurity) OnLogin(op *account_takeover.ProtectLoginOperation, args account_takeover.ProtectLoginOperationArg) {
+	op.Run(op, *inspector.NewInspectDataBuilder().WithAccountTakeover(args.ClientIP, args.UserID).Build())
+}
+
+func (s *AccountTakeoverSecurity) OnFinish(op *account_takeover.ProtectLoginOperation, res *account_takeover.ProtectLoginOperationResult) {
+	result := &waf.WafOperationResult{}
+	op.FinishInspect(result)
+
+	if result.IsBlock() {
+		res.BlockErr = result.BlockErr
+	}
+}

--- a/internal/rule/rules.json
+++ b/internal/rule/rules.json
@@ -234,6 +234,23 @@
           ]
         }
       ]
+    },
+    {
+      "id": "attempt-account-takeover",
+      "name": "account takeover attempt",
+      "tags": ["account-takeover"],
+      "action": "block",
+      "conditions": [
+        {
+          "inspector": "account_takeover",
+          "inspect_target": [
+            {
+              "target": "application.user.login.account_takeover"
+            }
+          ],
+          "threshold": 100
+        }
+      ]
     }
   ]
 }

--- a/internal/rule/ruls.go
+++ b/internal/rule/ruls.go
@@ -37,6 +37,8 @@ type Condition struct {
 
 	Regex     string   `json:"regex,omitempty"`
 	MatchList []string `json:"match_list,omitempty"`
+
+	Threshold float64 `json:"threshold,omitempty"`
 }
 
 func LoadDefaultRules() error {

--- a/lib/limitter/limitter.go
+++ b/lib/limitter/limitter.go
@@ -1,0 +1,25 @@
+// Package limtiter provides a simple rate limit using x/time/limit.
+// It is mainly intended for use in fraudulent login detection, such as credential stuffing.
+package limitter
+
+import (
+	"golang.org/x/time/rate"
+)
+
+type Limitter interface {
+	Allow() bool
+}
+
+type SimpleLimitter struct {
+	limiter *rate.Limiter
+}
+
+func NewLimitter(r rate.Limit, burst int) Limitter {
+	return &SimpleLimitter{
+		limiter: rate.NewLimiter(r, burst),
+	}
+}
+
+func (l *SimpleLimitter) Allow() bool {
+	return l.limiter.Allow()
+}

--- a/lib/limitter/limitter_test.go
+++ b/lib/limitter/limitter_test.go
@@ -1,0 +1,46 @@
+package limitter_test
+
+import (
+	"testing"
+
+	"github.com/sitebatch/waffle-go/lib/limitter"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+func TestLimitter_Allow(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		rate    int
+		reqSize int
+		expect  bool
+	}{
+		"If the rate limit is 10req and 10req are sent": {
+			rate:    10,
+			reqSize: 9,
+			expect:  true,
+		},
+		"If the rate limit is 10req and 11req are sent": {
+			rate:    10,
+			reqSize: 11,
+			expect:  false,
+		},
+	}
+
+	for name, tt := range testCases {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			l := limitter.NewLimitter(rate.Limit(tt.rate), tt.rate)
+
+			for i := 0; i < tt.reqSize; i++ {
+				l.Allow()
+			}
+
+			assert.Equal(t, tt.expect, l.Allow())
+		})
+	}
+}

--- a/waffle.go
+++ b/waffle.go
@@ -2,6 +2,7 @@ package waffle
 
 import (
 	"github.com/sitebatch/waffle-go/internal/listener"
+	"github.com/sitebatch/waffle-go/internal/listener/account_takeover"
 	"github.com/sitebatch/waffle-go/internal/listener/http"
 	"github.com/sitebatch/waffle-go/internal/listener/os"
 	"github.com/sitebatch/waffle-go/internal/listener/sql"
@@ -27,6 +28,7 @@ var listeners = []listener.NewListener{
 	http.NewHTTPClientSecurity,
 	sql.NewSQLSecurity,
 	os.NewFileSecurity,
+	account_takeover.NewAccountTakeoverSecurity,
 }
 
 func (w *Waffle) start() error {


### PR DESCRIPTION
Added simple implementation for detecting account takeover attempts by monitoring IP addresses and user IDs with high frequency login requests.

* Rate limiting implementation is memory-based and may not function correctly in distributed systems
* However, the implementation provides sufficient capability to detect credential stuffing attacks
